### PR TITLE
Add install target for garage-push

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -72,4 +72,7 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
   DEPENDS garage-push)
 
 add_dependencies(qa check)
+
+install(TARGETS garage-push DESTINATION /usr/bin)
+
 # vim: set tabstop=2 shiftwidth=2 expandtab:


### PR DESCRIPTION
It also makes Yocto happy. Probably there are hacks to build projects without "install" target as well, but I thing it's good to heve one anyway.