### PR TITLE
Added slash in case trailing slash is missing in credentials file

### DIFF
--- a/tools/treehub_server.cc
+++ b/tools/treehub_server.cc
@@ -25,7 +25,7 @@ void TreehubServer::SetToken(const string& token) {
 // this TreehubServer object alive until the curl request has been completed
 void TreehubServer::InjectIntoCurl(const string& url_suffix,
                                    CURL* curl_handle) const {
-  curl_easy_setopt(curl_handle, CURLOPT_URL, (root_url + url_suffix).c_str());
+  curl_easy_setopt(curl_handle, CURLOPT_URL, (root_url + "/" + url_suffix).c_str());
 
   curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, &auth_header_);
   if (!using_oauth2) {  // If we don't have a OAuth2 token fallback to legacy


### PR DESCRIPTION
It shouldn't break anything if slash is already present.