### PR TITLE
Fix include paths for auth_test.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -60,6 +60,7 @@ add_custom_target(check-tools
 
 add_dependencies(qa check-tools garage-push)
 
+include_directories(${PROJECT_SOURCE_DIR}/tools)
 add_subdirectory(t EXCLUDE_FROM_ALL)
 
 # Check the --help option works

--- a/tools/t/auth_test.cc
+++ b/tools/t/auth_test.cc
@@ -2,8 +2,8 @@
 
 #include <string>
 
-#include "../authenticate.h"
-#include "../treehub_server.h"
+#include "authenticate.h"
+#include "treehub_server.h"
 
 TEST(authenticate, good_zip) {
   std::string filepath = "tools/t/auth_test_good.zip";


### PR DESCRIPTION
Following advice from here:
https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes

Basically, it is better to handle include paths in the make/cmake logic
than in the source code itself.